### PR TITLE
increase test coverage

### DIFF
--- a/R/envvars.R
+++ b/R/envvars.R
@@ -1,3 +1,0 @@
-mcptools_log_file <- function() {
-  Sys.getenv("mcptools_LOG_FILE", tempfile(fileext = ".txt"))
-}

--- a/R/mcptools-package.R
+++ b/R/mcptools-package.R
@@ -1,3 +1,4 @@
+# nocov start
 #' @keywords internal
 "_PACKAGE"
 
@@ -14,3 +15,4 @@ NULL
     "ipc:///tmp/mcptools-socket"
   )
 }
+# nocov end

--- a/R/server.R
+++ b/R/server.R
@@ -1,6 +1,12 @@
 # The MCP server is a proxy. It takes input on stdin, and when the input forms
 # valid JSON, it will send the JSON to the session. Then, when it receives the
 # response, it will print the response to stdout.
+#
+# nocov start
+# mark as no test coverage as, when this is tested in `test-server.R`, the
+# function is called in a separate R process and thus isn't picked up by
+# coverage tools
+
 #' @param tools A list of tools created with [ellmer::tool()] that will be
 #' available from the server or a file path to an .R file that, when sourced,
 #' will return a list of tools. Any list that could be passed to
@@ -258,3 +264,5 @@ append_tool_fn <- function(data) {
   data$tool <- get_mcptools_tools()[[tool_name]]@fun
   data
 }
+
+# nocov end

--- a/R/session.R
+++ b/R/session.R
@@ -153,6 +153,10 @@ describe_session <- function() {
   sprintf("%d: %s (%s)", the$session, basename(getwd()), infer_ide())
 }
 
+# assign NULL for mocking in testing
+basename <- NULL
+getwd <- NULL
+
 infer_ide <- function() {
   first_cmd_arg <- commandArgs()[1]
   switch(

--- a/R/session.R
+++ b/R/session.R
@@ -112,7 +112,7 @@ handle_message_from_server <- function(data) {
 
 as_tool_call_result <- function(data, result) {
   is_error <- FALSE
-  if (inherits(result, "btw::BtwToolResult")) {
+  if (inherits(result, "ellmer::ContentToolResult")) {
     is_error <- !is.null(result@error)
     result <- result@value %||% result@error
   }
@@ -153,10 +153,6 @@ describe_session <- function() {
   sprintf("%d: %s (%s)", the$session, basename(getwd()), infer_ide())
 }
 
-# assign NULL for mocking in testing
-basename <- NULL
-getwd <- NULL
-
 infer_ide <- function() {
   first_cmd_arg <- commandArgs()[1]
   switch(
@@ -166,3 +162,8 @@ infer_ide <- function() {
     first_cmd_arg
   )
 }
+
+# assign NULL for mocking in testing
+basename <- NULL
+getwd <- NULL
+commandArgs <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,3 +26,7 @@ to_json <- function(x, ...) {
 }
 
 interactive <- NULL
+
+mcptools_log_file <- function() {
+  Sys.getenv("MCPTOOLS_LOG_FILE", tempfile(fileext = ".txt"))
+}

--- a/tests/testthat/_snaps/tools.md
+++ b/tests/testthat/_snaps/tools.md
@@ -24,3 +24,20 @@
       Error in `mcp_server()`:
       ! `tools` must be a list of tools created with `ellmer::tool()` or a .R file path that returns a list of ellmer tools when sourced.
 
+# set_server_tools errors informatively
+
+    Code
+      set_server_tools(tls$value[[1]])
+    Condition
+      Error:
+      ! `tls$value[[1]]` must be a list of tools created with `ellmer::tool()` or a .R file path that returns a list of ellmer tools when sourced.
+      i Did you mean to wrap `tls$value[[1]]` in `list()`?
+
+---
+
+    Code
+      set_server_tools(list(tls$value[[1]]))
+    Condition
+      Error:
+      ! The tool names list_r_sessions and select_r_session are reserved by mcptools.
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,0 +1,17 @@
+# jsonrpc_response works
+
+    Code
+      .res <- jsonrpc_response("789", result = "success", error = list(code = -32603,
+        message = "error"))
+    Condition
+      Warning in `jsonrpc_response()`:
+      Either `result` or `error` must be provided, but not both.
+
+---
+
+    Code
+      .res <- jsonrpc_response("000")
+    Condition
+      Warning in `jsonrpc_response()`:
+      Either `result` or `error` must be provided, but not both.
+

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -3,6 +3,58 @@ test_that("mcp_session returns early when not interactive", {
   expect_invisible(mcp_session())
 })
 
+test_that("mcp_session initializes appropriate globals", {
+  local_mocked_bindings(interactive = function() TRUE)
+  mcp_session()
+  expect_s3_class(the$session_socket, "nanoSocket")
+  expect_type(the$session, "integer")
+})
+
+test_that("as_tool_call_result handles normal results", {
+  data <- list(id = 1)
+  result <- "test result"
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$jsonrpc, "2.0")
+  expect_equal(output$id, 1)
+  expect_equal(output$result$content[[1]]$type, "text")
+  expect_equal(output$result$content[[1]]$text, "test result")
+  expect_false(output$result$isError)
+})
+
+test_that("as_tool_call_result handles ContentToolResult with value", {
+  data <- list(id = 1)
+
+  tool_result <- ellmer::ContentToolResult(value = "success result")
+
+  output <- as_tool_call_result(data, tool_result)
+
+  expect_equal(output$result$content[[1]]$text, "success result")
+  expect_false(output$result$isError)
+})
+
+test_that("as_tool_call_result handles ContentToolResult with error", {
+  data <- list(id = 1)
+
+  tool_result <- ellmer::ContentToolResult(error = "error message")
+
+  output <- as_tool_call_result(data, tool_result)
+
+  expect_equal(output$result$content[[1]]$text, "error message")
+  expect_true(output$result$isError)
+})
+
+test_that("as_tool_call_result handles vector results", {
+  data <- list(id = 1)
+  result <- c("line1", "line2", "line3")
+
+  output <- as_tool_call_result(data, result)
+
+  expect_equal(output$result$content[[1]]$text, "line1\nline2\nline3")
+  expect_false(output$result$isError)
+})
+
 test_that("drop_nulls works", {
   # drop_nulls removes NULL values from list
   result <- drop_nulls(list(a = 1, b = NULL, c = "text"))
@@ -32,4 +84,17 @@ test_that("describe_session works", {
   )
   result <- describe_session()
   expect_equal(result, "42: test-dir (Test IDE)")
+})
+
+test_that("infer_ide identifies different IDEs", {
+  local_mocked_bindings(commandArgs = function() c("ark", "other", "args"))
+  expect_equal(infer_ide(), "Positron")
+
+  local_mocked_bindings(commandArgs = function() c("RStudio", "other", "args"))
+  expect_equal(infer_ide(), "RStudio")
+
+  local_mocked_bindings(commandArgs = function() {
+    c("unknown-ide", "other", "args")
+  })
+  expect_equal(infer_ide(), "unknown-ide")
 })

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -1,0 +1,35 @@
+test_that("mcp_session returns early when not interactive", {
+  local_mocked_bindings(interactive = function() FALSE)
+  expect_invisible(mcp_session())
+})
+
+test_that("drop_nulls works", {
+  # drop_nulls removes NULL values from list
+  result <- drop_nulls(list(a = 1, b = NULL, c = "text"))
+  expect_equal(result, list(a = 1, c = "text"))
+  expect_equal(names(result), c("a", "c"))
+
+  # drop_nulls keeps non-NULL values
+  result <- drop_nulls(list(a = 1, b = 2, c = 3))
+  expect_equal(result, list(a = 1, b = 2, c = 3))
+
+  # drop_nulls handles empty list
+  result <- drop_nulls(list())
+  expect_equal(result, list())
+
+  # drop_nulls handles list with only NULL values
+  result <- drop_nulls(list(a = NULL, b = NULL))
+  expect_equal(result, named_list())
+  expect_equal(length(result), 0)
+})
+
+test_that("describe_session works", {
+  the$session <- 42
+  local_mocked_bindings(
+    basename = function(x) "test-dir",
+    getwd = function() "/path/to/test-dir",
+    infer_ide = function() "Test IDE"
+  )
+  result <- describe_session()
+  expect_equal(result, "42: test-dir (Test IDE)")
+})

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,3 +1,16 @@
+test_that("set_server_tools sets default tools when x is NULL", {
+  set_server_tools(NULL)
+  server_tools_names <- vapply(
+    the$server_tools,
+    function(x) x@name,
+    character(1)
+  )
+  expect_true(all(
+    c("list_r_sessions", "select_r_session") %in% server_tools_names
+  ))
+  expect_equal(length(the$server_tools), 2)
+})
+
 test_that("set_server_tools can handle `tools` as path", {
   tmp_file <- withr::local_tempfile(fileext = ".r")
   local_mocked_bindings(check_not_interactive = function(...) {})
@@ -20,4 +33,39 @@ test_that("set_server_tools can handle `tools` as path", {
     ))
   )
   expect_true("tool_rnorm" %in% names(the$server_tools))
+})
+
+test_that("set_server_tools errors informatively", {
+  tls <-
+    source(
+      system.file(
+        "example-ellmer-tools.R",
+        package = "mcptools"
+      ),
+      local = TRUE
+    )
+
+  # needs to be wrapped in `list()`
+  expect_snapshot(set_server_tools(tls$value[[1]]), error = TRUE)
+
+  # select_r_session and list_r_sessions are reserved names
+  tls$value[[1]]@name <- "select_r_session"
+  expect_snapshot(set_server_tools(list(tls$value[[1]])), error = TRUE)
+})
+
+test_that("get_mcptools_tools works", {
+  res <- get_mcptools_tools()
+  expect_true(all(
+    c("list_r_sessions", "select_r_session") %in% names(res)
+  ))
+})
+
+test_that("get_mcptools_tools_as_json works", {
+  res <- get_mcptools_tools_as_json()
+
+  expect_true(all(vapply(
+    res,
+    function(x) all(c(c("name", "description", "inputSchema")) %in% names(x)),
+    logical(1)
+  )))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -60,3 +60,16 @@ test_that("to_json works", {
   expect_equal(parsed$value, 42)
   expect_false(is.list(parsed$value))
 })
+
+test_that("mcptools_log_file works", {
+  # mcptools_log_file returns environment variable when set
+  withr::local_envvar(MCPTOOLS_LOG_FILE = "/custom/log/file.txt")
+  result <- mcptools_log_file()
+  expect_equal(result, "/custom/log/file.txt")
+
+  # mcptools_log_file returns tempfile when environment variable not set
+  withr::local_envvar(MCPTOOLS_LOG_FILE = NULL)
+  result <- mcptools_log_file()
+  expect_true(grepl("\\.txt$", result))
+  expect_true(file.exists(dirname(result)))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,30 @@
+test_that("jsonrpc_response works", {
+  # jsonrpc_response returns result when provided
+  result <- jsonrpc_response("123", result = "success")
+  expect_equal(result$jsonrpc, "2.0")
+  expect_equal(result$id, "123")
+  expect_equal(result$result, "success")
+  expect_null(result$error)
+
+  # jsonrpc_response returns error when provided
+  result <- jsonrpc_response(
+    "456",
+    error = list(code = -32603, message = "Internal error")
+  )
+  expect_equal(result$jsonrpc, "2.0")
+  expect_equal(result$id, "456")
+  expect_null(result$result)
+  expect_equal(result$error, list(code = -32603, message = "Internal error"))
+
+  # jsonrpc_response warns when both result and error provided
+  expect_snapshot(
+    .res <- jsonrpc_response(
+      "789",
+      result = "success",
+      error = list(code = -32603, message = "error")
+    )
+  )
+
+  # jsonrpc_response warns when neither result nor error provided
+  expect_snapshot(.res <- jsonrpc_response("000"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,3 +28,35 @@ test_that("jsonrpc_response works", {
   # jsonrpc_response warns when neither result nor error provided
   expect_snapshot(.res <- jsonrpc_response("000"))
 })
+
+test_that("named_list works", {
+  # named_list creates named list with arguments
+  result <- named_list(a = 1, b = 2)
+  expect_equal(result, list(a = 1, b = 2))
+  expect_true(is.list(result))
+  expect_equal(names(result), c("a", "b"))
+
+  # named_list creates empty named list when no arguments
+  result <- named_list()
+  expect_equal(result, list(a = 1)[0])
+  expect_true(is.list(result))
+  expect_equal(length(result), 0)
+  expect_true(!is.null(names(result)))
+})
+
+test_that("to_json works", {
+  # to_json converts list to JSON with auto_unbox
+  result <- to_json(list(a = 1, b = "text"))
+  expect_true(is.character(result))
+  expect_equal(jsonlite::fromJSON(result), list(a = 1, b = "text"))
+
+  # to_json passes additional arguments to jsonlite::toJSON
+  result <- to_json(list(a = 1), pretty = TRUE)
+  expect_true(grepl("\n", result))
+
+  # to_json handles single values with auto_unbox
+  result <- to_json(list(value = 42))
+  parsed <- jsonlite::fromJSON(result)
+  expect_equal(parsed$value, 42)
+  expect_false(is.list(parsed$value))
+})


### PR DESCRIPTION
Mostly focused on helpers. The test coverage appears lower than it actually is, as `mcp_server()` is invoked in a separate process when we test it.