### PR TITLE
future-proof for ellmer 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,12 +28,14 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
     cli,
-    ellmer (>= 0.2.0),
+    ellmer (>= 0.2.1.9000),
     jsonlite,
     nanonext (>= 1.6.0),
     processx,
     promises,
     rlang
+Remotes:
+    tidyverse/ellmer
 Depends: R (>= 4.1.0)
 URL: https://github.com/posit-dev/mcptools, https://posit-dev.github.io/mcptools/
 BugReports: https://github.com/posit-dev/mcptools/issues

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,2 +1,18 @@
 the <- new_environment()
 the$server_processes <- list()
+
+# ellmer 0.3.0 --------------------------------------------------------------
+# the ellmer 0.3.0 release will make a number of breaking changes.
+# we'll include a few functions to future-proof the initial release of mcptools
+# for that package release (#52).
+is_new_ellmer <- function() {
+  packageVersion("ellmer") >= "0.2.1.9000"
+}
+
+tool_fun <- function(tool) {
+  if (is_new_ellmer()) {
+    return(tool)
+  }
+
+  tool@fun
+}

--- a/R/client.R
+++ b/R/client.R
@@ -208,22 +208,41 @@ server_as_ellmer_tools <- function(server) {
   for (i in seq_along(tools)) {
     tool <- tools[[i]]
     tool_arguments <- as_ellmer_types(tool)
-    tools_out[[i]] <-
-      do.call(
-        ellmer::tool,
-        c(
-          list(
-            .fun = tool_ref(
-              server = server$name,
-              tool = tool$name,
-              arguments = names(tool_arguments)
-            ),
-            .description = tool$description,
-            .name = tool$name
-          ),
-          tool_arguments
+    if (is_new_ellmer()) {
+      tools_out[[i]] <-
+        do.call(
+          ellmer::tool,
+          c(
+            list(
+              fun = tool_ref(
+                server = server$name,
+                tool = tool$name,
+                arguments = names(tool_arguments)
+              ),
+              description = tool$description,
+              arguments = tool_arguments,
+              name = tool$name
+            )
+          )
         )
-      )
+    } else {
+      tools_out[[i]] <-
+        do.call(
+          ellmer::tool,
+          c(
+            list(
+              .fun = tool_ref(
+                server = server$name,
+                tool = tool$name,
+                arguments = names(tool_arguments)
+              ),
+              .description = tool$description,
+              .name = tool$name
+            ),
+            tool_arguments
+          )
+        )
+    }
   }
 
   tools_out

--- a/R/mcptools-package.R
+++ b/R/mcptools-package.R
@@ -7,6 +7,8 @@
 ## usethis namespace: end
 NULL
 
+utils::globalVariables(c("packageVersion", "setNames"))
+
 .onLoad <- function(libname, pkgname) {
   the$socket_url <- switch(
     Sys.info()[["sysname"]],

--- a/R/server.R
+++ b/R/server.R
@@ -261,7 +261,7 @@ append_tool_fn <- function(data) {
     ))
   }
 
-  data$tool <- get_mcptools_tools()[[tool_name]]@fun
+  data$tool <- tool_fun(get_mcptools_tools()[[tool_name]])
   data
 }
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -97,21 +97,30 @@ list_r_sessions <- function() {
   sort(as.character(nanonext::collect_aio_(res)))
 }
 
+list_r_sessions_description <- paste(
+  "List the R sessions that are available to access.",
+  "R sessions which have run `mcptools::mcp_session()` will appear here.",
+  "In the output, start each session with 'Session #' and do NOT otherwise",
+  "prefix any index numbers to the output.",
+  "In general, do not use this tool unless asked to list or",
+  "select a specific R session.",
+  "Given the output of this tool, report the users to the user.",
+  "Do NOT make a choice of R session based on the results of the tool",
+  "and call select_r_session unless the user asks you to specifically."
+)
+
 list_r_sessions_tool <-
-  ellmer::tool(
-    .fun = list_r_sessions,
-    .description = paste(
-      "List the R sessions that are available to access.",
-      "R sessions which have run `mcptools::mcp_session()` will appear here.",
-      "In the output, start each session with 'Session #' and do NOT otherwise",
-      "prefix any index numbers to the output.",
-      "In general, do not use this tool unless asked to list or",
-      "select a specific R session.",
-      "Given the output of this tool, report the users to the user.",
-      "Do NOT make a choice of R session based on the results of the tool",
-      "and call select_r_session unless the user asks you to specifically."
+  if (is_new_ellmer()) {
+    ellmer::tool(
+      fun = list_r_sessions,
+      description = list_r_sessions_description
     )
-  )
+  } else {
+    ellmer::tool(
+      .fun = list_r_sessions,
+      .description = list_r_sessions_description
+    )
+  }
 
 select_r_session <- function(session) {
   nanonext::reap(the$server_socket[["dialer"]][[1L]])
@@ -123,23 +132,35 @@ select_r_session <- function(session) {
   sprintf("Selected session %d successfully.", session)
 }
 
+select_r_session_description <- paste(
+  "Choose the R session of interest.",
+  "Use the `list_r_sessions` tool to discover potential sessions.",
+  "In general, do not use this tool unless asked to select a specific R",
+  "session; the tools available to you have a default R session",
+  "that is usually the one the user wants.",
+  "Do not call this tool immediately after calling list_r_sessions",
+  "unless you've been asked to select an R session and haven't yet",
+  "called list_r_sessions.",
+  "Your choice of session will persist after the tool is called; only",
+  "call this tool more than once if you need to switch between sessions."
+)
+
 select_r_session_tool <-
-  ellmer::tool(
-    .fun = select_r_session,
-    .description = paste(
-      "Choose the R session of interest.",
-      "Use the `list_r_sessions` tool to discover potential sessions.",
-      "In general, do not use this tool unless asked to select a specific R",
-      "session; the tools available to you have a default R session",
-      "that is usually the one the user wants.",
-      "Do not call this tool immediately after calling list_r_sessions",
-      "unless you've been asked to select an R session and haven't yet",
-      "called list_r_sessions.",
-      "Your choice of session will persist after the tool is called; only",
-      "call this tool more than once if you need to switch between sessions."
-    ),
-    session = ellmer::type_integer("The R session number to select.")
-  )
+  if (is_new_ellmer()) {
+    ellmer::tool(
+      fun = select_r_session,
+      description = select_r_session_description,
+      arguments = list(
+        session = ellmer::type_integer("The R session number to select.")
+      )
+    )
+  } else {
+    ellmer::tool(
+      .fun = select_r_session,
+      .description = select_r_session_description,
+      session = ellmer::type_integer("The R session number to select.")
+    )
+  }
 
 get_mcptools_tools <- function() {
   # must be called inside of the server session

--- a/inst/example-ellmer-tools.R
+++ b/inst/example-ellmer-tools.R
@@ -1,13 +1,36 @@
-list(
-  tool_rnorm = ellmer::tool(
-    rnorm,
-    "Drawn numbers from a random normal distribution",
-    n = ellmer::type_integer(
-      "The number of observations. Must be a positive integer."
-    ),
-    mean = ellmer::type_number("The mean value of the distribution."),
-    sd = ellmer::type_number(
-      "The standard deviation of the distribution. Must be a non-negative number."
-    ),
-  )
-)
+if (is_new_ellmer()) {
+  res <-
+    list(
+      tool_rnorm = ellmer::tool(
+        fun = rnorm,
+        description = "Draw numbers from a random normal distribution",
+        arguments = list(
+          n = ellmer::type_integer(
+            "The number of observations. Must be a positive integer."
+          ),
+          mean = ellmer::type_number("The mean value of the distribution."),
+          sd = ellmer::type_number(
+            "The standard deviation of the distribution. Must be a non-negative number."
+          )
+        )
+      )
+    )
+} else {
+  res <-
+    list(
+      tool_rnorm = ellmer::tool(
+        rnorm,
+        "Draw numbers from a random normal distribution",
+        n = ellmer::type_integer(
+          "The number of observations. Must be a positive integer."
+        ),
+        mean = ellmer::type_number("The mean value of the distribution."),
+        sd = ellmer::type_number(
+          "The standard deviation of the distribution. Must be a non-negative number."
+        ),
+      )
+    )
+}
+
+
+res


### PR DESCRIPTION
Closes #52, cc @hadley!

* Calls to `tool()` have new argument structure.
* The tool itself is the tool function in ellmer 0.3.0, while before then the tool function is in the `@fun` slot.